### PR TITLE
Feat: cloudwatch exporter를 위한 IAM, IRSA, ServiceAccount 추가

### DIFF
--- a/service/iam/cloudwatchexporter.tf
+++ b/service/iam/cloudwatchexporter.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_policy" "cloudwatchexporter_policy" {
+  name = var.cloudwatchexporter_policy_name
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:GetMetricData", 
+          "cloudwatch:ListMetrics",
+          "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+          "ec2:DescribeAvailabilityZones",
+          "rds:DescribeDBInstances",
+          "elasticache:DescribeCacheClusters",
+          "cloudfront:ListDistributions"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "cloudwatchexporter_irsa" {
+  name = "${var.name_prefix}-monitoring-cloudwatchexporter-irsa-role"
+  
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = var.eks_oidc_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(var.eks_oidc_url, "https://", "")}:sub" = "system:serviceaccount/${var.monitoring_namespace}/${var.cloudwatchexporter_service_account}"
+          }
+        }
+      }
+    ]
+  })
+  
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatchexporter_policy_attach" {
+  role       = aws_iam_role.cloudwatchexporter_irsa.name
+  policy_arn = aws_iam_policy.cloudwatchexporter_policy.arn
+}
+
+resource "kubernetes_service_account" "cloudwatchexporter_sa" {
+  metadata {
+    name      = var.cloudwatchexporter_service_account
+    namespace = kubernetes_namespace.monitoring.metadata[0].name
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.cloudwatchexporter_irsa.arn
+    }
+  }
+}

--- a/service/iam/outputs.tf
+++ b/service/iam/outputs.tf
@@ -33,3 +33,14 @@ output "externaldns_irsa_role_arn" {
   value       = aws_iam_role.externaldns_irsa.arn
   description = "IAM role ARN used by ExternalDNS"
 }
+
+#
+output "cloudwatchexporter_irsa_role_arn" {
+  value       = aws_iam_role.cloudwatchexporter_irsa.arn
+  description = "IAM role ARN used by CloudWatch Exporter"
+}
+
+output "cloudwatchexporter_service_account" {
+  value       = kubernetes_service_account.cloudwatchexporter_sa.metadata[0].name
+  description = "Service account for CloudWatch Exporter"
+}

--- a/service/iam/variables.tf
+++ b/service/iam/variables.tf
@@ -73,14 +73,14 @@ variable "externaldns_service_account" {
 }
 
 # CloudWatch Exporter-specific
-variable "cloudwatch_exporter_policy_name" {
+variable "cloudwatchexporter_policy_name" {
   type        = string
   default     = "CloudWatchExporterReadOnly"
   description = "IAM policy name for CloudWatch Exporter"
 }
 
-variable "cloudwatch_exporter_service_account" {
+variable "cloudwatchexporter_service_account" {
   type        = string
-  default     = "cloudwatch-exporter-sa"
+  default     = "cloudwatchexporter-sa"
   description = "Service account name for CloudWatch Exporter"
 }

--- a/service/iam/variables.tf
+++ b/service/iam/variables.tf
@@ -71,3 +71,16 @@ variable "externaldns_service_account" {
   type        = string
   default     = "externaldns-sa"
 }
+
+# CloudWatch Exporter-specific
+variable "cloudwatch_exporter_policy_name" {
+  type        = string
+  default     = "CloudWatchExporterReadOnly"
+  description = "IAM policy name for CloudWatch Exporter"
+}
+
+variable "cloudwatch_exporter_service_account" {
+  type        = string
+  default     = "cloudwatch-exporter-sa"
+  description = "Service account name for CloudWatch Exporter"
+}


### PR DESCRIPTION
### 생성되는 리소스들
- AWS 리소스
  - IAM Policy: CloudWatchExporterReadOnly
  - IAM Role: matchfit-monitoring-cloudwatchexporter-irsa-role
  
</br>

- Kubernetes 리소스:
  - ServiceAccount: cloudwatchexporter-sa (monitoring 네임스페이스)
  
</br>

- IRSA 연동:
  - ServiceAccount에 IAM Role ARN annotation 자동 설정
  - CloudWatch API 접근 권한 자동 부여